### PR TITLE
Remove deprecated Error / Success Functions

### DIFF
--- a/sandcastle/tools/chocolateyuninstall.ps1
+++ b/sandcastle/tools/chocolateyuninstall.ps1
@@ -1,15 +1,7 @@
 ﻿# stop on all errors
 $ErrorActionPreference = 'Stop';
 
-$packageName = 'sandcastle'
+$msiPackageGuid = '{07BAE775-6B29-4D6D-974B-57C5BFA5EF59}'
+$msiArgs = "/x $msiPackageGuid /qn REBOOT=ReallySuppress"
 
-try
-{
-	$msiPackageGuid = '{07BAE775-6B29-4D6D-974B-57C5BFA5EF59}'
-	$msiArgs = "/x $msiPackageGuid /qn REBOOT=ReallySuppress"
-
-	Start-ChocolateyProcessAsAdmin "$msiArgs" 'msiexec'
-	Write-ChocolateySuccess $package
-} catch {
-	Write-ChocolateyFailure $packageName "$($_.Exception.Message)"
-}
+Start-ChocolateyProcessAsAdmin "$msiArgs" 'msiexec'


### PR DESCRIPTION
Remove deprecated Error / Success Functions. See [Choco documentation](https://github.com/chocolatey/choco/wiki/HelpersReference#user-content-error--success-functions).